### PR TITLE
Trim form input

### DIFF
--- a/js/github.js
+++ b/js/github.js
@@ -37,8 +37,8 @@ function fromQuery(value) {
 }
 
 function getRepo(branch) {
-  var owner = $('input#owner').val(),
-    repo = $('input#repo').val(),
+  var owner = $('input#owner').val().trim(),
+      repo = $('input#repo').val().trim(),
     queryString = 'owner=' + owner + '&repo=' + repo + (branch ? '&branch=' + branch : '') + (exclude ? '&exclude=' + exclude.join() : '');
   window.history.pushState({}, '', window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + queryString);
   $('img#logo').attr('src', 'images/hex-loader.gif');


### PR DESCRIPTION
On certain platforms, usually mobile, spaces are automatically inserted after typing/auto-completion. When I first tried using the visualizer I ran into this same issue!

To solve it, I remove any white space from either end of each key.